### PR TITLE
Fix postcss-preset-env stage issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,12 @@ In browser this css will be translated to
 
 [styled-jsx-plugin-root-theme-provider](https://github.com/nawaf331/styled-jsx-plugin-root-theme-provider) uses [styled-jsx](https://github.com/zeit/styled-jsx#css-preprocessing-via-plugins)'s plugin system which is supported from version 2. Read more on their repository for further info.
 
+## Options
+
+**themeFilePath [Optional]** : To configure theme css file path
+**postcssPresetEnvOptions [Optional]** : To configure postcss-preset-env
+
+#### Default stage for postcss-preset-env is 0
 
 ## Contributing
 

--- a/fixture-theme.css
+++ b/fixture-theme.css
@@ -1,3 +1,5 @@
 :root {
   --red: red;
 }
+
+@custom-media --small-viewport (max-width: 30em);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "styled-jsx-plugin-root-theme-provider",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -28,6 +28,18 @@
         "num2fraction": "^1.2.2",
         "postcss": "^6.0.23",
         "postcss-value-parser": "^3.2.3"
+      },
+      "dependencies": {
+        "postcss": {
+          "version": "6.0.23",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+          "requires": {
+            "chalk": "^2.4.1",
+            "source-map": "^0.6.1",
+            "supports-color": "^5.4.0"
+          }
+        }
       }
     },
     "balanced-match": {
@@ -348,9 +360,9 @@
       "dev": true
     },
     "postcss": {
-      "version": "6.0.23",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
-      "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.2.tgz",
+      "integrity": "sha512-fmaUY5370keLUTx+CnwRxtGiuFTcNBLQBqr1oE3WZ/euIYmGAo0OAgOhVJ3ByDnVmOR3PK+0V9VebzfjRIUcqw==",
       "requires": {
         "chalk": "^2.4.1",
         "source-map": "^0.6.1",
@@ -364,6 +376,18 @@
       "requires": {
         "postcss": "^6.0.23",
         "postcss-selector-parser": "^4.0.0"
+      },
+      "dependencies": {
+        "postcss": {
+          "version": "6.0.23",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+          "requires": {
+            "chalk": "^2.4.1",
+            "source-map": "^0.6.1",
+            "supports-color": "^5.4.0"
+          }
+        }
       }
     },
     "postcss-color-functional-notation": {
@@ -373,6 +397,18 @@
       "requires": {
         "postcss": "^6.0.23",
         "postcss-values-parser": "^1.5.0"
+      },
+      "dependencies": {
+        "postcss": {
+          "version": "6.0.23",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+          "requires": {
+            "chalk": "^2.4.1",
+            "source-map": "^0.6.1",
+            "supports-color": "^5.4.0"
+          }
+        }
       }
     },
     "postcss-color-hex-alpha": {
@@ -383,6 +419,18 @@
         "color": "^1.0.3",
         "postcss": "^6.0.1",
         "postcss-message-helpers": "^2.0.0"
+      },
+      "dependencies": {
+        "postcss": {
+          "version": "6.0.23",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+          "requires": {
+            "chalk": "^2.4.1",
+            "source-map": "^0.6.1",
+            "supports-color": "^5.4.0"
+          }
+        }
       }
     },
     "postcss-color-mod-function": {
@@ -393,6 +441,18 @@
         "@csstools/convert-colors": "^1.4.0",
         "postcss": "^6.0.23",
         "postcss-values-parser": "^1.5.0"
+      },
+      "dependencies": {
+        "postcss": {
+          "version": "6.0.23",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+          "requires": {
+            "chalk": "^2.4.1",
+            "source-map": "^0.6.1",
+            "supports-color": "^5.4.0"
+          }
+        }
       }
     },
     "postcss-color-rebeccapurple": {
@@ -402,6 +462,18 @@
       "requires": {
         "postcss": "^6.0.22",
         "postcss-values-parser": "^1.5.0"
+      },
+      "dependencies": {
+        "postcss": {
+          "version": "6.0.23",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+          "requires": {
+            "chalk": "^2.4.1",
+            "source-map": "^0.6.1",
+            "supports-color": "^5.4.0"
+          }
+        }
       }
     },
     "postcss-custom-media": {
@@ -410,6 +482,18 @@
       "integrity": "sha1-vlMnhBEOyylQRPtTlaGABushpzc=",
       "requires": {
         "postcss": "^6.0.1"
+      },
+      "dependencies": {
+        "postcss": {
+          "version": "6.0.23",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+          "requires": {
+            "chalk": "^2.4.1",
+            "source-map": "^0.6.1",
+            "supports-color": "^5.4.0"
+          }
+        }
       }
     },
     "postcss-custom-properties": {
@@ -419,6 +503,18 @@
       "requires": {
         "balanced-match": "^1.0.0",
         "postcss": "^6.0.18"
+      },
+      "dependencies": {
+        "postcss": {
+          "version": "6.0.23",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+          "requires": {
+            "chalk": "^2.4.1",
+            "source-map": "^0.6.1",
+            "supports-color": "^5.4.0"
+          }
+        }
       }
     },
     "postcss-custom-selectors": {
@@ -428,6 +524,18 @@
       "requires": {
         "postcss": "^6.0.1",
         "postcss-selector-matches": "^3.0.0"
+      },
+      "dependencies": {
+        "postcss": {
+          "version": "6.0.23",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+          "requires": {
+            "chalk": "^2.4.1",
+            "source-map": "^0.6.1",
+            "supports-color": "^5.4.0"
+          }
+        }
       }
     },
     "postcss-dir-pseudo-class": {
@@ -437,6 +545,18 @@
       "requires": {
         "postcss": "^6.0.22",
         "postcss-selector-parser": "^4.0.0"
+      },
+      "dependencies": {
+        "postcss": {
+          "version": "6.0.23",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+          "requires": {
+            "chalk": "^2.4.1",
+            "source-map": "^0.6.1",
+            "supports-color": "^5.4.0"
+          }
+        }
       }
     },
     "postcss-env-function": {
@@ -446,6 +566,18 @@
       "requires": {
         "postcss": "^6.0.22",
         "postcss-values-parser": "^1.5.0"
+      },
+      "dependencies": {
+        "postcss": {
+          "version": "6.0.23",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+          "requires": {
+            "chalk": "^2.4.1",
+            "source-map": "^0.6.1",
+            "supports-color": "^5.4.0"
+          }
+        }
       }
     },
     "postcss-focus-visible": {
@@ -454,6 +586,18 @@
       "integrity": "sha512-6i3HsOrWNelxBYPh/HWAXF9lPwCFAfFVlUTZqsLRXYMPhcXH1eXdItozRBvT9l5pYF4ddJJbgk4JOp0au0QToA==",
       "requires": {
         "postcss": "^6.0"
+      },
+      "dependencies": {
+        "postcss": {
+          "version": "6.0.23",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+          "requires": {
+            "chalk": "^2.4.1",
+            "source-map": "^0.6.1",
+            "supports-color": "^5.4.0"
+          }
+        }
       }
     },
     "postcss-focus-within": {
@@ -462,6 +606,18 @@
       "integrity": "sha512-LTbT/dxZ3FahpOv1XZMyRLNnBk5QWVU4HL/p82iFkzoPNVhNQazaYIujHXTOAKea5clgjbj6GdFj7mU7qzy1kQ==",
       "requires": {
         "postcss": "^6.0.21"
+      },
+      "dependencies": {
+        "postcss": {
+          "version": "6.0.23",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+          "requires": {
+            "chalk": "^2.4.1",
+            "source-map": "^0.6.1",
+            "supports-color": "^5.4.0"
+          }
+        }
       }
     },
     "postcss-font-family-system-ui": {
@@ -470,6 +626,18 @@
       "integrity": "sha512-58G/hTxMSSKlIRpcPUjlyo6hV2MEzvcVO2m4L/T7Bb2fJTG4DYYfQjQeRvuimKQh1V1sOzCIz99g+H2aFNtlQw==",
       "requires": {
         "postcss": "^6.0"
+      },
+      "dependencies": {
+        "postcss": {
+          "version": "6.0.23",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+          "requires": {
+            "chalk": "^2.4.1",
+            "source-map": "^0.6.1",
+            "supports-color": "^5.4.0"
+          }
+        }
       }
     },
     "postcss-font-variant": {
@@ -478,6 +646,18 @@
       "integrity": "sha1-CMzIj2BQuoLtjvLMdsDGprQfGD4=",
       "requires": {
         "postcss": "^6.0.1"
+      },
+      "dependencies": {
+        "postcss": {
+          "version": "6.0.23",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+          "requires": {
+            "chalk": "^2.4.1",
+            "source-map": "^0.6.1",
+            "supports-color": "^5.4.0"
+          }
+        }
       }
     },
     "postcss-gap-properties": {
@@ -486,6 +666,18 @@
       "integrity": "sha512-snL2k0Nie72J0uCsKgfO2Sd5rs3Wlhsk+k9uVzyMaeBH9gouNPPY7tZ4bopRJmBISbZEUtvF8Gchat6nOFQHdg==",
       "requires": {
         "postcss": "^6.0.22"
+      },
+      "dependencies": {
+        "postcss": {
+          "version": "6.0.23",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+          "requires": {
+            "chalk": "^2.4.1",
+            "source-map": "^0.6.1",
+            "supports-color": "^5.4.0"
+          }
+        }
       }
     },
     "postcss-image-set-function": {
@@ -495,6 +687,18 @@
       "requires": {
         "postcss": "^6.0.22",
         "postcss-values-parser": "^1.5.0"
+      },
+      "dependencies": {
+        "postcss": {
+          "version": "6.0.23",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+          "requires": {
+            "chalk": "^2.4.1",
+            "source-map": "^0.6.1",
+            "supports-color": "^5.4.0"
+          }
+        }
       }
     },
     "postcss-initial": {
@@ -504,6 +708,18 @@
       "requires": {
         "lodash.template": "^4.2.4",
         "postcss": "^6.0.1"
+      },
+      "dependencies": {
+        "postcss": {
+          "version": "6.0.23",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+          "requires": {
+            "chalk": "^2.4.1",
+            "source-map": "^0.6.1",
+            "supports-color": "^5.4.0"
+          }
+        }
       }
     },
     "postcss-lab-function": {
@@ -514,6 +730,18 @@
         "@csstools/convert-colors": "^1.4.0",
         "postcss": "^6.0.23",
         "postcss-values-parser": "^1.5.0"
+      },
+      "dependencies": {
+        "postcss": {
+          "version": "6.0.23",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+          "requires": {
+            "chalk": "^2.4.1",
+            "source-map": "^0.6.1",
+            "supports-color": "^5.4.0"
+          }
+        }
       }
     },
     "postcss-logical": {
@@ -522,6 +750,18 @@
       "integrity": "sha512-ZJgyLJlp3uPKae9+6sJKFjD06UZzb/m3M1LPeHsaBMvvyatcNWwCfOZVIq00fJdxUqa9QeuQO6RZElKmRdWMEg==",
       "requires": {
         "postcss": "^6.0.20"
+      },
+      "dependencies": {
+        "postcss": {
+          "version": "6.0.23",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+          "requires": {
+            "chalk": "^2.4.1",
+            "source-map": "^0.6.1",
+            "supports-color": "^5.4.0"
+          }
+        }
       }
     },
     "postcss-media-minmax": {
@@ -530,6 +770,18 @@
       "integrity": "sha1-Z1JWA3pD70C8Twdgv9BtTcadSNI=",
       "requires": {
         "postcss": "^6.0.1"
+      },
+      "dependencies": {
+        "postcss": {
+          "version": "6.0.23",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+          "requires": {
+            "chalk": "^2.4.1",
+            "source-map": "^0.6.1",
+            "supports-color": "^5.4.0"
+          }
+        }
       }
     },
     "postcss-message-helpers": {
@@ -543,6 +795,18 @@
       "integrity": "sha512-Yoglsy6eZbDCbRIXoYSmnIt9ao4xyg07iFwVBd7WyIkDzMSeRxIqUk8xEAdkeJQ7eGfWo6RufrTU7FSUjZ22fg==",
       "requires": {
         "postcss": "^6.0.22"
+      },
+      "dependencies": {
+        "postcss": {
+          "version": "6.0.23",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+          "requires": {
+            "chalk": "^2.4.1",
+            "source-map": "^0.6.1",
+            "supports-color": "^5.4.0"
+          }
+        }
       }
     },
     "postcss-overflow-shorthand": {
@@ -551,6 +815,18 @@
       "integrity": "sha512-QeJk23W8dLP2DrWYSKTwfFfh4Tcy5Msr58vuuxCPcCijX/07jva0OGNKtUH9vZ6NnXB2WEsnfIIg5M0ScPEWeQ==",
       "requires": {
         "postcss": "^6.0.22"
+      },
+      "dependencies": {
+        "postcss": {
+          "version": "6.0.23",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+          "requires": {
+            "chalk": "^2.4.1",
+            "source-map": "^0.6.1",
+            "supports-color": "^5.4.0"
+          }
+        }
       }
     },
     "postcss-page-break": {
@@ -559,6 +835,18 @@
       "integrity": "sha512-FgjJ7q/cQFbfQFdmm15XDu+DjNb6Tcn7LYm+o1CxyHV5p6pCm0jkRhuU+PF6FaMrSTfy5nF8nuWhwOtUQyWiYA==",
       "requires": {
         "postcss": "^6.0.16"
+      },
+      "dependencies": {
+        "postcss": {
+          "version": "6.0.23",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+          "requires": {
+            "chalk": "^2.4.1",
+            "source-map": "^0.6.1",
+            "supports-color": "^5.4.0"
+          }
+        }
       }
     },
     "postcss-place": {
@@ -568,6 +856,18 @@
       "requires": {
         "postcss": "^6.0.22",
         "postcss-values-parser": "^1.5.0"
+      },
+      "dependencies": {
+        "postcss": {
+          "version": "6.0.23",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+          "requires": {
+            "chalk": "^2.4.1",
+            "source-map": "^0.6.1",
+            "supports-color": "^5.4.0"
+          }
+        }
       }
     },
     "postcss-preset-env": {
@@ -608,6 +908,18 @@
         "postcss-replace-overflow-wrap": "^2.0.0",
         "postcss-selector-matches": "^3.0.1",
         "postcss-selector-not": "^3.0.1"
+      },
+      "dependencies": {
+        "postcss": {
+          "version": "6.0.23",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+          "requires": {
+            "chalk": "^2.4.1",
+            "source-map": "^0.6.1",
+            "supports-color": "^5.4.0"
+          }
+        }
       }
     },
     "postcss-pseudo-class-any-link": {
@@ -617,6 +929,18 @@
       "requires": {
         "postcss": "^6.0.22",
         "postcss-selector-parser": "^4.0.0"
+      },
+      "dependencies": {
+        "postcss": {
+          "version": "6.0.23",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+          "requires": {
+            "chalk": "^2.4.1",
+            "source-map": "^0.6.1",
+            "supports-color": "^5.4.0"
+          }
+        }
       }
     },
     "postcss-replace-overflow-wrap": {
@@ -625,6 +949,18 @@
       "integrity": "sha1-eU22+qVPjbEAhUOSqTr0V2i04ls=",
       "requires": {
         "postcss": "^6.0.1"
+      },
+      "dependencies": {
+        "postcss": {
+          "version": "6.0.23",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+          "requires": {
+            "chalk": "^2.4.1",
+            "source-map": "^0.6.1",
+            "supports-color": "^5.4.0"
+          }
+        }
       }
     },
     "postcss-selector-matches": {
@@ -640,6 +976,16 @@
           "version": "0.4.2",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
           "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
+        },
+        "postcss": {
+          "version": "6.0.23",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+          "requires": {
+            "chalk": "^2.4.1",
+            "source-map": "^0.6.1",
+            "supports-color": "^5.4.0"
+          }
         }
       }
     },
@@ -656,6 +1002,16 @@
           "version": "0.4.2",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
           "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
+        },
+        "postcss": {
+          "version": "6.0.23",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+          "requires": {
+            "chalk": "^2.4.1",
+            "source-map": "^0.6.1",
+            "supports-color": "^5.4.0"
+          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "styled-jsx-plugin-root-theme-provider",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Plugin to use `var` and `:root` css power to build themed styled-jsx with older browser support",
   "main": "index.js",
   "scripts": {
@@ -28,6 +28,7 @@
   "homepage": "https://github.com/FareFirst/styled-jsx-plugin-root-theme-provider#readme",
   "dependencies": {
     "deasync": "^0.1.13",
+    "postcss": "^7.0.2",
     "postcss-preset-env": "^5.3.0"
   },
   "devDependencies": {

--- a/test.js
+++ b/test.js
@@ -11,8 +11,27 @@ describe('styled-jsx-plugin-root-theme-provider', () => {
 
   it('applies theme', () => {
     assert.equal(
-      plugin('.selector {background: var(--red)}', { themeFilePath: './fixture-theme.css' }),
-      '.selector {background: red;background: var(--red)}'
+      plugin('.selector {background: var(--red);}', { themeFilePath: './fixture-theme.css' }),
+      '.selector {background: red;background: var(--red);}'
+    )
+  })
+
+  it('applies postcss-custom-media', () => {
+    assert.equal(
+      plugin('@media (--small-viewport) {b {font-size: 1em;}}', { themeFilePath: './fixture-theme.css' }),
+      '@media (max-width: 30em) {b {font-size: 1em;}}'
+    )
+  })
+
+  it('applies postcssPresetEnvOptions', () => {
+    assert.equal(
+      plugin('@media (--small-viewport) {b {font-size: 1em;}}', {
+        themeFilePath: './fixture-theme.css',
+        postcssPresetEnvOptions: {
+          stage: 2
+        }
+      }),
+      '@media (--small-viewport) {b {font-size: 1em;}}'
     )
   })
 })

--- a/theme-processor.js
+++ b/theme-processor.js
@@ -1,14 +1,12 @@
 const loopWhile = require('deasync').loopWhile
 const fs = require('fs')
 
-module.exports = (css, options) => {
-  const NAMESPACE = '/* ##styled-jsx-plugin-ff-theme## */'
+const NAMESPACE = '/* ##styled-jsx-plugin-ff-theme## */'
+const NAMESPACE_REGEX = /\/\* ##styled-jsx-plugin-ff-theme## \*\/[^]*\/\* ##styled-jsx-plugin-ff-theme## \*\//
 
+const addTheme = (css, options) => {
   const { themeFilePath } = options
-  if (!themeFilePath) return {
-    namespacedTheme: NAMESPACE,
-    cssToBeProcessed: `${NAMESPACE}${css}`
-  }
+  if (!themeFilePath) return css;
 
   let theme
   let wait = true
@@ -24,10 +22,13 @@ module.exports = (css, options) => {
   });
   loopWhile(() => wait)
 
-  const namespacedTheme = `${NAMESPACE}${theme}${NAMESPACE}`
-  const cssToBeProcessed = `${namespacedTheme}${css}`
-  return {
-    namespacedTheme,
-    cssToBeProcessed
-  }
+  const cssToBeProcessed = `${NAMESPACE}${theme}${NAMESPACE}${css}`
+  return cssToBeProcessed;
+}
+
+const removeTheme = css => css.replace(NAMESPACE_REGEX, '');
+
+module.exports = {
+  addTheme,
+  removeTheme
 }


### PR DESCRIPTION
By default `postcss-preset-env` uses stage 2, which doesn't include custom media query feature.

Fixed:
* Now using stage 0 by default for postcss-preset-env
* Added configuration for passing options to postcss-preset-env
